### PR TITLE
Fix error retrieving files

### DIFF
--- a/tests.el
+++ b/tests.el
@@ -60,7 +60,7 @@
 (ert-deftest speed-type--retrieve-test ()
   (let ((filename "speed-type--retrieve-test-file")
         (filename-expected "/tmp/speed-type--retrieve-test-file.txt")
-        (url "https://google.es"))
+        (url "https://www.google.com"))
 
     (speed-type--retrieve-non-exitant-file-environment
      filename-expected
@@ -78,4 +78,16 @@
          (should (stringp filename-response))
          (should (string= filename-response filename-expected))
          (should (file-exists-p filename-expected))
-         (should (file-readable-p filename-expected)))))))
+         (should (file-readable-p filename-expected))))))
+
+  (let ((filename "speed-type--retrieve-test-file")
+        (filename-expected "/tmp/speed-type--retrieve-test-file.txt")
+        (url "https://www.google.com/nonexitanresource"))
+
+    (speed-type--retrieve-non-exitant-file-environment
+     filename-expected
+     (lambda ()
+       (let ((filename-response (speed-type--retrieve filename url)))
+         (should (eq nil filename-response))
+         (should (not (file-exists-p filename-expected)))
+         (should (not (file-readable-p filename-expected))))))))


### PR DESCRIPTION
Hi! 

First of all, thanks for this software that has give me so much joy lately.

I would like to contribute on it preventing to people type a HTTP error 404 when there is an error downloading the a book. Not the best literature master piece!

Pasted the commit message for more information:

It prevents to create a file when an error rise while downloading a
book. Other wise the user will be prompted to type a HTTP error 404
page or other alike.

When this happen 'speed-type' exits with a message error on the
minibuffer telling the user about a download error with a given book number.