### PR TITLE
Add custom default face

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -91,6 +91,11 @@ E.g. if you always want lowercase words, set:
   :type '(choice (const :tag "None" nil)
                  (symbol :tag "Language")))
 
+(defface speed-type-default
+  '()
+  "Default face for `speed-type'."
+  :group 'speed-type)
+
 (defface speed-type-correct
   '((t :foreground "green"))
   "Face for correctly typed characters."
@@ -390,6 +395,7 @@ language symbol and N-WORDS is the top N words that should be trained."
         (len (length text)))
     (set-buffer buf)
     (speed-type-mode)
+    (buffer-face-set 'speed-type-default)
     (setq speed-type--orig-text text)
     (setq speed-type--mod-str (make-string len 0))
     (setq speed-type--remaining len)


### PR DESCRIPTION
Hi!

I have been always scaling the size of the face for me to make it confortable. With this pull request I am able to customize the default face size as a please across each speed-type session.

--

A custom default face enable the user to set different face for
speed-type.