### PR TITLE
speed-type-mode major mode

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -389,6 +389,7 @@ language symbol and N-WORDS is the top N words that should be trained."
   (let ((buf (generate-new-buffer "speed-type"))
         (len (length text)))
     (set-buffer buf)
+    (speed-type-mode)
     (setq speed-type--orig-text text)
     (setq speed-type--mod-str (make-string len 0))
     (setq speed-type--remaining len)

--- a/speed-type.el
+++ b/speed-type.el
@@ -39,6 +39,10 @@
   "Practice touch-typing in Emacs."
   :group 'games)
 
+(define-derived-mode speed-type-mode fundamental-mode "SpeedType"
+  "Major mode for practicing touch typing."
+  :group "speed-type")
+
 (defcustom speed-type-min-chars 200
   "The minimum number of chars to type required when the text is picked randomly."
   :group 'speed-type

--- a/tests.el
+++ b/tests.el
@@ -25,3 +25,16 @@
                      (speed-type--trim "\n\nfoo\n\t\sbar\n\n\n")))
     (should (string= "\tfoo\n\t\sbar"
                      (speed-type--trim "\n\tfoo\n\t\sbar\n\n\n\n"))))
+
+(ert-deftest speed-type-mode-test()
+  (let* ((hook-executed nil))
+    (defun speed-type-mode-test-hook ()
+      (setq hook-executed t))
+    (unwind-protect
+        (progn
+          (add-hook 'speed-type-mode-hook 'speed-type-mode-test-hook)
+          (with-temp-buffer
+            (speed-type-mode)
+            (kill-current-buffer))
+          (should (equal hook-executed t)))
+      (remove-hook 'speed-type-mode-hook 'speed-type-mode-test-hook))))


### PR DESCRIPTION
Hi!

This PR creates a major mode for our touch typing practicing tool.

This major modes derives from fundamental-mode, so noting fancy but it allows user to register hooks to their typing practices, making the experience more personal.

As an example, I have a hook to activate olivetti-mode (what else could have been!!) on my emacs configuration file:

```emacs-lisp
        (use-package olivetti
          :diminish "Olivetti"
          :commands
          olivetti-mode
          :hook
          ((speed-type-mode org-mode) . olivetti-mode))
```
    
I hope you can enjoy it!
