### PR TITLE
Make sure view-mode is disabled in completion window

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -312,7 +312,8 @@ Accuracy is computed as (CORRECT-ENTRIES - CORRECTIONS) / TOTAL-ENTRIES."
                   (propertize "r" 'face 'highlight)))
   (insert (format "    [%s]ext random sample\n"
                   (propertize "n" 'face 'highlight)))
-  (read-only-mode)
+  (let ((view-read-only nil))
+    (read-only-mode))
   (use-local-map speed-type--completed-keymap))
 
 (defun speed-type--diff (orig new start end)


### PR DESCRIPTION
Users who have set `view-read-only` to `t` somewhere in their
configurations will not be able to make use of the
`speed-type--completed-keymap`; `view-mode`, being a major mode,
overwrites all of these bindings.

Hence, make sure that this variable is disabled in the time we are
calling `read-only-mode`.