### PR TITLE
Speed Typing a Region of Code

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -521,7 +521,6 @@ been completed."
                                     :replay-fn (speed-type--get-replay-fn go-next-fn)
                                     :go-next-fn go-next-fn)))
 
-;;;###autoload
 (defun speed-type-code-tab ()
   "A command to be mapped to TAB when speed typing code."
   (interactive)
@@ -530,21 +529,11 @@ been completed."
     (goto-char start)
     (when end (insert (buffer-substring-no-properties start (1- end))))))
 
-;;;###autoload
 (defun speed-type-code-ret ()
   "A command to be mapped to RET when speed typing code."
   (interactive)
   (when (= (point) (line-end-position))
     (newline) (move-beginning-of-line nil) (speed-type-code-tab)))
-		     
-;;;###autoload
-(defun speed-type-code-region (start end)
-  "Open copy of [START,END] in a new buffer to speed type the code."
-  (interactive "r")
-  (speed-type--code-with-highlighting (buffer-substring-no-properties start end)
-                                      (syntax-table)
-                                      font-lock-defaults
-                                      nil))
 
 ;;;###autoload
 (defun speed-type-top-x (n)
@@ -591,7 +580,11 @@ been completed."
 (defun speed-type-region (start end)
   "Open copy of [START,END] in a new buffer to speed type the text."
   (interactive "r")
-  (speed-type--setup (buffer-substring-no-properties start end)))
+  (if (derived-mode-p 'prog-mode)
+      (speed-type--code-with-highlighting (buffer-substring-no-properties start end)
+                                          (syntax-table)
+                                          font-lock-defaults)
+    (speed-type--setup (buffer-substring-no-properties start end))))
 
 ;;;###autoload
 (defun speed-type-buffer (full)

--- a/speed-type.el
+++ b/speed-type.el
@@ -456,6 +456,7 @@ CALLBACK is called when the setup process has been completed."
       (goto-char 0)
       (add-hook 'after-change-functions 'speed-type--change nil t)
       (add-hook 'first-change-hook 'speed-type--first-change nil t)
+      (setq-local post-self-insert-hook nil)
       (when callback (funcall callback))
       (message "Timer will start when you type the first character."))))
 

--- a/speed-type.el
+++ b/speed-type.el
@@ -159,7 +159,6 @@ Total errors: %d
 (defvar-local speed-type--author nil)
 (defvar-local speed-type--lang nil)
 (defvar-local speed-type--n-words nil)
-(defvar-local speed-type--opened-on-buffer nil)
 (defvar-local speed-type--go-next-fn nil)
 (defvar-local speed-type--replay-fn #'speed-type--setup)
 


### PR DESCRIPTION
This PR is essentially the same as #24 but with conflicts fixed, I've closed that one since not using a feature branch was too much of a pain :slightly_smiling_face: .  Apologies for the large diff, hopefully if you've already reviewed #24 it shouldn't be much different.

Original text:

----------------------------------
Hi! This PR adds a function `speed-type-code-region` which works essentially the same as `speed-type-region`, but preserves any syntax highlighting (apologies for gif quality):

![speed type code region demo](https://user-images.githubusercontent.com/17688577/89201196-0519fd00-d5a9-11ea-8a44-f5fa3bf72a35.gif)

Additional changes:

- Use overlays instead of `add-text-properties`
- Use lexical binding
- Instead of hard coding replay and play next functions, introduce buffer local variables which point to functions to be called when the user chooses replay or go next
- Omit play next button if it does not make sense in context (e.g. when speed typing a buffer)