### PR TITLE
Fix speed-type--retrieve Test Failure

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -245,17 +245,19 @@ Accuracy is computed as (CORRECT-ENTRIES - CORRECTIONS) / TOTAL-ENTRIES."
         fn
       (make-directory speed-type-gb-dir 'parents)
       (let ((buffer (url-retrieve-synchronously url nil nil 5)))
-        (with-current-buffer buffer
-          (write-region url-http-end-of-headers (point-max) fn))
-        (unless (kill-buffer buffer)
-          (message "WARNING: Buffer is not closing properly"))
-        (if (file-readable-p fn)
+        (when (and buffer (= 200 (url-http-symbol-value-in-buffer
+                                  'url-http-response-status
+                                  buffer)))
+          (with-current-buffer buffer
+            (write-region url-http-end-of-headers (point-max) fn))
+          (unless (kill-buffer buffer)
+            (message "WARNING: Buffer is not closing properly"))
+          (when (file-readable-p fn)
             (with-temp-file fn
               (insert-file-contents fn)
               (delete-trailing-whitespace)
               (decode-coding-region (point-min) (point-max) 'utf-8))
-          (setq fn nil))
-        fn))))
+            fn))))))
 
 (defun speed-type--gb-retrieve (book-num)
   "Return buffer with book number BOOK-NUM in it."

--- a/test-speed-type.el
+++ b/test-speed-type.el
@@ -43,7 +43,7 @@
           (should (equal hook-executed t)))
       (remove-hook 'speed-type-mode-hook 'speed-type-mode-test-hook))))
 
-(defun speed-type--retrieve-non-exitant-file-environment (filename-expected test)
+(defun speed-type--retrieve-non-existant-file-environment (filename-expected test)
   (let ((speed-type-gb-dir "/tmp"))
     (unwind-protect
         (progn
@@ -51,7 +51,7 @@
           (funcall test))
       (delete-file filename-expected))))
 
-(defun speed-type--retrieve-exitant-file-environment (filename-expected test)
+(defun speed-type--retrieve-existant-file-environment (filename-expected test)
   (let ((speed-type-gb-dir "/tmp"))
     (unwind-protect
         (progn
@@ -66,7 +66,7 @@
         (filename-expected "/tmp/speed-type--retrieve-test-file.txt")
         (url "https://www.google.com"))
 
-    (speed-type--retrieve-non-exitant-file-environment
+    (speed-type--retrieve-non-existant-file-environment
      filename-expected
      (lambda ()
        (let ((filename-response (speed-type--retrieve filename url)))
@@ -75,7 +75,7 @@
          (should (file-exists-p filename-expected))
          (should (file-readable-p filename-expected)))))
 
-    (speed-type--retrieve-exitant-file-environment
+    (speed-type--retrieve-existant-file-environment
      filename-expected
      (lambda ()
        (let ((filename-response (speed-type--retrieve filename url)))
@@ -88,10 +88,10 @@
         (filename-expected "/tmp/speed-type--retrieve-test-file.txt")
         (url "https://www.google.com/nonexitanresource"))
 
-    (speed-type--retrieve-non-exitant-file-environment
+    (speed-type--retrieve-non-existant-file-environment
      filename-expected
      (lambda ()
        (let ((filename-response (speed-type--retrieve filename url)))
-         (should (eq nil filename-response))
+         (should (null filename-response))
          (should (not (file-exists-p filename-expected)))
          (should (not (file-readable-p filename-expected))))))))


### PR DESCRIPTION
Hi, this PR is a follow up from #35, the issue was when a GET request to `speed-type--retrieve` returns a non 200 status code, `nil` was not returned, this PR fixes that by just checking the status code.

All tests are passing locally for me, I see you've added ci in the last commit, hopefully that should pass now for this PR - EDIT: alright looks good!