### PR TITLE
inherit the colors for correct and mistake faces from success and warning respectively

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -109,12 +109,12 @@ To remove without replacement, use the form: `(bad-string . \"\")'"
   :group 'speed-type)
 
 (defface speed-type-correct
-  '((t :foreground "green"))
+  `((t (:inherit 'default :foreground ,(face-foreground 'success))))
   "Face for correctly typed characters."
   :group 'speed-type)
 
 (defface speed-type-mistake
-  '((t :foreground "red" :underline "red"))
+  `((t (:inherit 'default :foreground ,(face-foreground 'error) :underline t)))
   "Face for incorrectly typed characters."
   :group 'speed-type)
 


### PR DESCRIPTION
Since there is a huge variance in the visibility of green and red in various themes it might be better to inherit the colors for speed-type-correct and speed-type-mistake from the the success and warning faces which are usually set by the theme being used. The reason to not inherit from them directly from those faces was in-case the theme does something weird like using a different weight or having boxes etc...