### PR TITLE
Add speed type statistic file with median calculation, add-word-feature from typer-mode and various bug-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# speed-type [![melpa badge][melpa-badge]][melpa-link] [![melpa stable badge][melpa-stable-badge]][melpa-stable-link]
+# Fork of speed-type
 
 Practice touch/speed typing in GNU Emacs.
 
@@ -6,21 +6,23 @@ Practice touch/speed typing in GNU Emacs.
 
 ## Installation
 
-Install speed-type from [MELPA](melpa.org) with:
+Because this is a Fork it’s not available on melpa.
 
-```
-M-x package-install RET speed-type
-```
-
-If you prefer to install by hand: Put speed-type.el into a directory specified
-by the load-path variable. Alternatively, you can add a directory to the
-variable load-path by (add-to-list 'load-path "ADDITIONAL-DIRECTORY").
-
-If you put the file in "~/.emacs.d/speed-type/speed-type.el" for instance, the
-following snipped in your .emacs file will load and init the extension.
-
+You can use an `el-patch` with `straight`:
 ```emacs-lisp
-(add-to-list 'load-path "~/.emacs.d/speed-type/speed-type.el")
+(use-package speed-type
+  :straight (speed-type :type git :host github :repo "lordnik22/speed-type"))
+```
+
+Alternatively, you can clone this project
+```
+mkdir -p ~/.emacs.d/elisp
+cd ~/.emacs.d/elisp
+git clone https://github.com/lordnik22/speed-type.git
+```
+...and add it to the load-path in your init-file:
+```
+(add-to-list 'load-path "~/.emacs.d/elisp/speed-type")
 (require 'speed-type)
 ```
 
@@ -31,6 +33,17 @@ speed-type can be customized using:
 ```
 M-x customize-group speed-type RET
 ```
+
+## Why a Fork?
+
+If you like this fork also give a star to the origin: https://github.com/dakra/speed-type
+
+Main differences:
+- content-buffer from which the speed-type-buffer retrieves it’s content
+- integrated add-word-feature from typer-mode
+- some bugfixes and more consistent state-handling
+- deactivate keys which can break a typing session (e.g. fill-paragraph)
+- refactored code at some places
 
 ## Running speed-type
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fork of speed-type
+# speed-type [![melpa badge][melpa-badge]][melpa-link] [![melpa stable badge][melpa-stable-badge]][melpa-stable-link]
 
 Practice touch/speed typing in GNU Emacs.
 
@@ -6,44 +6,23 @@ Practice touch/speed typing in GNU Emacs.
 
 ## Installation
 
-Because this is a Fork it’s not available on melpa.
+Install speed-type from [MELPA](melpa.org) with:
 
-You can use an `el-patch` with `straight`:
+```
+M-x package-install RET speed-type
+```
+
+If you prefer to install by hand: Put speed-type.el into a directory specified
+by the load-path variable. Alternatively, you can add a directory to the
+variable load-path by (add-to-list 'load-path "ADDITIONAL-DIRECTORY").
+
+If you put the file in "~/.emacs.d/speed-type/speed-type.el" for instance, the
+following snipped in your .emacs file will load and init the extension.
+
 ```emacs-lisp
-(use-package speed-type
-  :straight (speed-type :type git :host github :repo "lordnik22/speed-type"))
-```
-
-Alternatively, you can clone this project
-```
-mkdir -p ~/.emacs.d/elisp
-cd ~/.emacs.d/elisp
-git clone https://github.com/lordnik22/speed-type.git
-```
-...and add it to the load-path in your init-file:
-```
-(add-to-list 'load-path "~/.emacs.d/elisp/speed-type")
+(add-to-list 'load-path "~/.emacs.d/speed-type/speed-type.el")
 (require 'speed-type)
 ```
-
-## Configuration
-
-speed-type can be customized using:
-
-```
-M-x customize-group speed-type RET
-```
-
-## Why a Fork?
-
-If you like this fork also give a star to the origin: https://github.com/dakra/speed-type
-
-Main differences:
-- content-buffer from which the speed-type-buffer retrieves it’s content
-- integrated add-word-feature from typer-mode
-- some bugfixes and more consistent state-handling
-- deactivate keys which can break a typing session (e.g. fill-paragraph)
-- refactored code at some places
 
 ## Running speed-type
 
@@ -71,6 +50,33 @@ the selected region.
 `speed-type-top-x` (or -100/-1000) lets you practice the top X words
 for the selected language.
 
+## Customization
+
+See all custom variables of speed-type pressing:
+```
+M-x customize-group speed-type RET
+```
+
+### Statistics
+
+The default of `speed-type-save-statistic-option` is `always` which
+means speed-type session data is stored to file
+`speed-type-statistic-filename`. All values which you see at the end
+of each speed-type session are stored there.
+
+You can display the calculated medians from the data by pressing `d`
+at the end of a speed-type session.
+
+### Add words on error (typer-mode)
+
+The default of `speed-type-add-extra-words-on-mistake` is `0` which
+means no additional words are added on misstyping. If you like to
+challange yourself you can set this to a number higher than 0.
+Depending on your accuracy we recommanded a number between 1 and 7.
+
+It adds random or next words from the content the speed-type session
+took his content. If you replay the session, the added words will be
+included.
 
 [melpa-link]: https://melpa.org/#/speed-type
 [melpa-stable-link]: https://stable.melpa.org/#/speed-type

--- a/speed-type.el
+++ b/speed-type.el
@@ -35,15 +35,25 @@
 ;; stats (WPM, CPM, accuracy) while you are typing.
 
 ;;; Code:
-
 (require 'cl-lib)
 (require 'url)
 (require 'url-handlers)
 (require 'url-http)
+(require 'thingatpt)
 
 (defgroup speed-type nil
   "Practice touch-typing in Emacs."
   :group 'games)
+
+(defcustom speed-type-buffer-name "*speed-type*"
+  "Name of buffer in which the user completes his typing session."
+  :group 'speed-type
+  :type 'string)
+
+(defcustom speed-type-content-buffer-name "*speed-type-content-buffer*"
+  "Name of buffer consisting of the content-source for the speed-type buffer."
+  :group 'speed-type
+  :type 'string)
 
 (defcustom speed-type-min-chars 200
   "The minimum number of chars to type required when the text is picked randomly."
@@ -102,6 +112,13 @@ E.g. if you always want lowercase words, set:
 To remove without replacement, use the form: `(bad-string . \"\")'"
   :type '(alist :key-type string :value-type string))
 
+(defcustom speed-type-add-extra-words-on-mistake 0
+  "How many new words should be added on mistake.
+When 0 or less, no words are added. The typing-session will only
+be complete when these extra words are typed too."
+  :group 'speed-type
+  :type 'integer)
+
 (defface speed-type-default
   '()
   "Default face for `speed-type'."
@@ -150,6 +167,7 @@ Total errors: %d
 (defvar speed-type-mode-map
   (let ((keymap (make-sparse-keymap)))
     (define-key keymap (kbd "C-c C-k")  #'speed-type-complete)
+    (define-key keymap (kbd "M-q") #'speed-type-fill-paragraph)
     keymap)
   "Keymap for `speed-type-mode'.")
 
@@ -161,6 +179,8 @@ Total errors: %d
 
 (defvar-local speed-type--start-time nil)
 (defvar-local speed-type--orig-text nil)
+(defvar-local speed-type--buffer nil)
+(defvar-local speed-type--content-buffer nil)
 (defvar-local speed-type--entries 0)
 (defvar-local speed-type--errors 0)
 (defvar-local speed-type--remaining 0)
@@ -170,6 +190,9 @@ Total errors: %d
 (defvar-local speed-type--author nil)
 (defvar-local speed-type--lang nil)
 (defvar-local speed-type--n-words nil)
+(defvar-local speed-type--add-extra-word-content-fn nil)
+(defvar-local speed-type--extra-words-animation-time nil)
+(defvar-local speed-type--extra-words-queue '())
 (defvar-local speed-type--go-next-fn nil)
 (defvar-local speed-type--replay-fn #'speed-type--setup)
 
@@ -189,7 +212,7 @@ Otherwise return 0."
 
 Computes words-per-minute as (ENTRIES/5) / (SECONDS/60)."
   (round (speed-type--/ (/ entries 5.0)
-                        (speed-type--seconds-to-minutes seconds))))
+              (speed-type--seconds-to-minutes seconds))))
 
 (defun speed-type--gross-cpm (entries seconds)
   "Return gross characters-per-minute.
@@ -204,7 +227,7 @@ Computes net words-per-minute as:
   ((ENTRIES/5) - UNCORRECTED-ERRORS) / (SECONDS/60)."
   (let ((net-wpm (round (- (speed-type--gross-wpm entries seconds)
                            (speed-type--/ uncorrected-errors
-                                          (speed-type--seconds-to-minutes seconds))))))
+                                (speed-type--seconds-to-minutes seconds))))))
     (if (> 0 net-wpm) 0 net-wpm)))
 
 (defun speed-type--net-cpm (entries uncorrected-errors seconds)
@@ -214,7 +237,7 @@ Computes net characters-per-minute as:
   (ENTRIES - UNCORRECTED-ERRORS) / (SECONDS/60)."
   (let ((net-cpm (round (- (speed-type--gross-cpm entries seconds)
                            (speed-type--/ uncorrected-errors
-                                          (speed-type--seconds-to-minutes seconds))))))
+                                (speed-type--seconds-to-minutes seconds))))))
     (if (> 0 net-cpm) 0 net-cpm)))
 
 (defun speed-type--accuracy (total-entries correct-entries corrections)
@@ -321,46 +344,59 @@ Accuracy is computed as (CORRECT-ENTRIES - CORRECTIONS) / TOTAL-ENTRIES."
   (interactive)
   (when speed-type--replay-fn
     (let ((fn speed-type--replay-fn)
-          (text speed-type--orig-text))
-      (kill-this-buffer)
-      (funcall fn text))))
+	  (cb (current-buffer)))
+      (funcall fn)
+      (kill-buffer cb))))
 
 (defun speed-type--play-next ()
   "Play a new speed-type session, based on the current one."
   (interactive)
   (when speed-type--go-next-fn
-    (let ((fn speed-type--go-next-fn))
-      (kill-this-buffer)
-      (funcall fn))))
+    (let ((fn speed-type--go-next-fn)
+	  (cb (current-buffer)))
+      (funcall fn)
+      (kill-buffer cb))))
+
+(defun speed-type-fill-paragraph ()
+  "Override keybinding of fill-paragraph with this to not destory session."
+  (interactive)
+  (message "Fill paragraph not available"))
 
 (defun speed-type-complete ()
   "Remove typing hooks from the buffer and print statistics."
   (interactive)
   (remove-hook 'after-change-functions 'speed-type--change)
   (remove-hook 'first-change-hook 'speed-type--first-change)
+  (speed-type-finish-animation speed-type--buffer)
   (goto-char (point-max))
-  (when speed-type--title
-    (insert "\n\n")
-    (insert (propertize speed-type--title 'face 'italic))
-    (when speed-type--author
-      (insert (propertize
-               (format ", by %s" speed-type--author)
-               'face 'italic))))
-  (insert (speed-type--generate-stats
-           speed-type--entries
-           speed-type--errors
-           speed-type--corrections
-           (speed-type--elapsed-time)))
-  (insert "\n\n")
-  (insert (format "    [%s]uit\n"
-                  (propertize "q" 'face 'highlight)))
-  (insert (format "    [%s]eplay this sample\n"
-                  (propertize "r" 'face 'highlight)))
-  (when speed-type--go-next-fn (insert (format "    [%s]ext random sample\n"
-                                               (propertize "n" 'face 'highlight))))
-  (let ((view-read-only nil))
-    (read-only-mode))
-  (use-local-map speed-type--completed-keymap))
+  (with-current-buffer speed-type--buffer
+    (when speed-type--title
+      (insert "\n\n")
+      (save-excursion
+	(insert (propertize speed-type--title 'face 'italic))
+	(when speed-type--author
+	  (insert (propertize
+		   (format ", by %s" speed-type--author)
+		   'face 'italic)))
+	(insert (speed-type--generate-stats
+		 speed-type--entries
+		 speed-type--errors
+		 speed-type--corrections
+		 (speed-type--elapsed-time)))
+	(insert "\n\n")
+	(insert (format "    [%s]uit\n"
+			(propertize "q" 'face 'highlight)))
+	(insert (format "    [%s]eplay this sample\n"
+			(propertize "r" 'face 'highlight)))
+	(when speed-type--go-next-fn (insert (format "    [%s]ext random sample\n"
+					   (propertize "n" 'face 'highlight)))))
+      (let ((this-scroll-margin
+	     (min (max 0 scroll-margin)
+		  (truncate (/ (window-body-height) 4.0)))))
+	(recenter this-scroll-margin t))
+    (let ((view-read-only nil))
+      (read-only-mode))
+    (use-local-map speed-type--completed-keymap))))
 
 (defun speed-type--diff (orig new start end)
   "Update stats and buffer contents with result of changes in text."
@@ -374,7 +410,8 @@ Accuracy is computed as (CORRECT-ENTRIES - CORRECTIONS) / TOTAL-ENTRIES."
             (progn (setq correct t)
                    (store-substring speed-type--mod-str pos0 1))
           (progn (cl-incf speed-type--errors)
-                 (store-substring speed-type--mod-str pos0 2)))
+                 (store-substring speed-type--mod-str pos0 2)
+		 (when speed-type-add-extra-words-on-mistake (speed-type-add-extra-words))))
         (cl-incf speed-type--entries)
         (cl-decf speed-type--remaining)
 	(let ((overlay (make-overlay pos (1+ pos))))
@@ -428,7 +465,7 @@ Replacements are found in `speed-type-replace-strings'."
    :initial-value text))
 
 (cl-defun speed-type--setup
-    (text &key author title lang n-words replay-fn go-next-fn callback)
+    (content-buffer text &key author title lang n-words add-extra-word-content-fn replay-fn go-next-fn callback)
   "Set up a new buffer for the typing exercise on TEXT.
 
 AUTHOR and TITLE can be given, this happen when the text to type comes
@@ -436,6 +473,12 @@ from a gutenberg book.
 
 LANG and N-WORDS are used when training random words where LANG is the
 language symbol and N-WORDS is the top N words that should be trained.
+
+CONTENT-BUFFER defines the source from which the typing session
+get his content.
+
+If specified, call ADD-EXTRA-WORD-CONTENT-FN which provides an extra
+line when user makes an mistake.
 
 If specified, call REPLAY-FN after completion of a speed type session
 and replay is selected.  REPLAY-FN should take one argument, a string
@@ -452,30 +495,73 @@ CALLBACK is called when the setup process has been completed."
       (insert text)
       (delete-trailing-whitespace)
       (setq text (speed-type--trim (buffer-string))))
-    (let ((buf (generate-new-buffer "speed-type"))
+    (let ((buf (generate-new-buffer speed-type-buffer-name))
           (len (length text)))
       (set-buffer buf)
       (speed-type-mode)
       (buffer-face-set 'speed-type-default)
-      (setq speed-type--orig-text text)
-      (setq speed-type--mod-str (make-string len 0))
-      (setq speed-type--remaining len)
-      (setq speed-type--author author)
-      (setq speed-type--title title)
-      (setq speed-type--lang lang)
-      (setq speed-type--n-words n-words)
-      (setq speed-type--go-next-fn go-next-fn)
-      (when replay-fn
-        (setq speed-type--replay-fn replay-fn))
+      (setq speed-type--orig-text text
+	    speed-type--mod-str (make-string len 0)
+	    speed-type--remaining len
+	    speed-type--author author
+	    speed-type--title title
+	    speed-type--lang lang
+	    speed-type--n-words n-words
+	    speed-type--add-extra-word-content-fn add-extra-word-content-fn
+	    speed-type--go-next-fn go-next-fn)
+      (when content-buffer
+	(setq speed-type--content-buffer content-buffer)
+	(setq-local speed-type--buffer buf))
+      (with-current-buffer speed-type--content-buffer (setq-local speed-type--buffer buf))
+      (when replay-fn (setq speed-type--replay-fn replay-fn))
       (insert text)
+      (unless (with-current-buffer speed-type--content-buffer (derived-mode-p 'prog-mode))
+	(fill-region (point-min) (point-max) 'none t))
       (set-buffer-modified-p nil)
       (switch-to-buffer buf)
       (goto-char 0)
       (add-hook 'after-change-functions 'speed-type--change nil t)
       (add-hook 'first-change-hook 'speed-type--first-change nil t)
+      (add-hook 'kill-buffer-hook 'speed-type--kill-buffer-hook nil t)
       (setq-local post-self-insert-hook nil)
       (when callback (funcall callback))
       (message "Timer will start when you type the first character."))))
+
+(defun speed-type-prepare-content-buffer-from-buffer (buffer)
+  "Prepare content buffer from existing BUFFER."
+  (let ((buf (generate-new-buffer speed-type-content-buffer-name)))
+    (with-current-buffer buf
+      (add-hook 'kill-buffer-hook 'speed-type--kill-content-buffer-hook nil t)
+      (insert-buffer-substring buffer)
+      (setq buffer-read-only nil)
+      (funcall (buffer-local-value 'major-mode buffer))
+      (goto-char (point-min)))
+    (get-buffer-create buf)))
+
+(defun speed-type-prepare-content-buffer (file-path)
+  "Prepare content buffer from FILE-PATH."
+  (let ((buf (generate-new-buffer speed-type-content-buffer-name)))
+    (with-current-buffer buf
+      (add-hook 'kill-buffer-hook 'speed-type--kill-content-buffer-hook nil t)
+      (insert-file-contents file-path)
+      (setq buffer-read-only nil)
+      (goto-char (point-min))
+      (get-buffer-create buf))))
+
+(defun speed-type--kill-buffer-hook ()
+  "Hook when speed-type buffer is killed."
+  (when speed-type--extra-words-animation-time (cancel-timer speed-type--extra-words-animation-time))
+  (when speed-type--content-buffer
+    (let ((buf speed-type--content-buffer))
+      (setq speed-type--content-buffer nil)
+      (kill-buffer buf))))
+
+(defun speed-type--kill-content-buffer-hook ()
+  "Hook when content buffer is killed."
+  (when speed-type--buffer
+    (let ((buf speed-type--buffer))
+      (setq speed-type--buffer nil)
+      (kill-buffer buf))))
 
 (defun speed-type--pick-text-to-type (&optional start end)
   "Return a random section of the buffer usable for playing.
@@ -484,37 +570,39 @@ START and END allow to limit to a buffer section - they default
 to (point-min) and (point-max)"
   (unless start (setq start (point-min)))
   (unless end (setq end (point-max)))
-  (save-mark-and-excursion
-    (goto-char start)
-    (forward-paragraph
-     ;; count the paragraphs, and pick a random one
-     (random (let ((nb 0))
-               (while (< (point) end)
-                 (forward-paragraph)
-                 (setq nb (+ 1 nb)))
-               (goto-char start)
-               nb)))
-    (mark-paragraph)
-    ;; select more paragraphs until there are more than speed-type-min-chars
-    ;; chars in the selection
-    (while (and (< (mark) end)
-                (< (- (mark) (point)) speed-type-min-chars))
-      (mark-paragraph 1 t))
-    (exchange-point-and-mark)
-    ;; and remove sentences if we are above speed-type-max-chars
-    (let ((continue t)
-          (sentence-end-double-space nil)
-          (fwd nil))
-      (while (and (< (point) end)
-                  (> (- (point) (mark)) speed-type-max-chars)
-                  continue)
-        (setq continue (re-search-backward (sentence-end) (mark) t))
-        (when continue (setq fwd t)))
-      (when fwd (forward-char)))
-    (buffer-substring-no-properties (region-beginning) (region-end))))
+  (goto-char start)
+  (forward-paragraph
+   ;; count the paragraphs, and pick a random one
+   (random (let ((nb 0))
+             (while (< (point) end)
+               (forward-paragraph)
+               (setq nb (+ 1 nb)))
+             (goto-char start)
+             nb)))
+  (mark-paragraph)
+  ;; select more paragraphs until there are more than speed-type-min-chars
+  ;; chars in the selection
+
+  (while (and (< (mark) end)
+              (< (- (mark) (point)) speed-type-min-chars))
+    (mark-paragraph 1 t))
+  (exchange-point-and-mark)
+  ;; and remove sentences if we are above speed-type-max-chars
+
+  (let ((continue t)
+        (sentence-end-double-space nil)
+        (fwd nil))
+    (while (and (< (point) end)
+                (> (- (point) (mark)) speed-type-max-chars)
+                continue)
+      (setq continue (re-search-backward (sentence-end) (mark) t))
+      (when continue (setq fwd t)))
+    (when fwd (forward-char)))
+  (unless (derived-mode-p 'prog-mode) (fill-region (region-beginning) (region-end) 'none t))
+  (buffer-substring-no-properties (region-beginning) (region-end)))
 
 (defun speed-type--setup-code
-    (text &optional replay-fn go-next-fn syntax-table font-lock-df)
+    (content-buffer text title author &optional replay-fn go-next-fn syntax-table font-lock-df)
   "Speed type the code snippet TEXT.
 
 If specified, call REPLAY-FN after completion of a speed type session
@@ -525,20 +613,22 @@ For code highlighting, a syntax table can be specified by SYNTAX-TABLE,
 and font lock defaults by FONT-LOCK-DF."
   (cl-flet ((callback ()
                       (electric-pair-mode -1)
-                      (local-set-key (kbd "TAB") 'speed-type-code-tab)
-                      (local-set-key (kbd "RET") 'speed-type-code-ret)
+                      (local-set-key (kbd "TAB") 'speed-type--code-tab)
+                      (local-set-key (kbd "RET") 'speed-type--code-ret)
                       (when syntax-table (set-syntax-table syntax-table))
                       (when font-lock-df
                         (let ((font-lock-defaults font-lock-df))
                           ;; Fontify buffer
                           (ignore-errors (font-lock-ensure))))))
-    (speed-type--setup text
-                       :replay-fn replay-fn
-                       :go-next-fn go-next-fn
-                       :callback #'callback)))
+    (speed-type--setup content-buffer
+	     text
+	     :author author
+	     :title title
+	     :replay-fn replay-fn
+             :go-next-fn go-next-fn
+             :callback #'callback)))
 
-(defun speed-type--code-with-highlighting
-    (text &optional syntax-table font-lock-df go-next-fn)
+(defun speed-type--code-with-highlighting (content-buffer text title author &optional syntax-table font-lock-df go-next-fn)
   "Speed type TEXT with syntax highlighting.
 
 Syntax highlighting data is given by SYNTAX-TABLE and
@@ -546,17 +636,113 @@ FONT-LOCK-DF (font lock defaults).
 
 If GO-NEXT-FN is specified, call it when speed typing the text has
 been completed."
-  (cl-flet ((replay-fn (text) (speed-type--code-with-highlighting
-                               text syntax-table font-lock-df go-next-fn)))
-    (speed-type--setup-code text #'replay-fn go-next-fn syntax-table font-lock-df)))
+  (speed-type--setup-code content-buffer
+		text
+		title
+		author
+		#'speed-type--get-replay-fn
+		go-next-fn
+		syntax-table
+		font-lock-df))
 
-(defun speed-type--get-replay-fn (go-next-fn)
+(defun speed-type--get-replay-fn ()
   "Return a replay function which will use GO-NEXT-FN after completion."
-  (lambda (text) (speed-type--setup text
-                                    :replay-fn (speed-type--get-replay-fn go-next-fn)
-                                    :go-next-fn go-next-fn)))
+  (remove-hook 'kill-buffer-hook 'speed-type--kill-buffer-hook t)
+  (if (with-current-buffer speed-type--content-buffer
+	(derived-mode-p 'prog-mode))
+      (speed-type--code-with-highlighting
+       speed-type--content-buffer
+       speed-type--orig-text
+       speed-type--title
+       speed-type--author
+       (with-current-buffer speed-type--content-buffer (syntax-table))
+       (with-current-buffer speed-type--content-buffer font-lock-defaults)
+       speed-type--go-next-fn)
+    (speed-type--setup speed-type--content-buffer
+	     speed-type--title
+	     speed-type--orig-text
+	     :lang speed-type--lang
+	     :author speed-type--author
+	     :title speed-type--title
+	     :n-words speed-type--n-words
+	     :add-extra-word-content-fn speed-type--add-extra-word-content-fn
+             :replay-fn #'speed-type--get-replay-fn
+             :go-next-fn speed-type--go-next-fn)))
 
-(defun speed-type-code-tab ()
+(defun speed-type--get-next-word (content-buffer)
+  "Get next word from point in CONTENT-BUFFER."
+  (with-current-buffer content-buffer
+    (forward-word)
+    (if (= (point-max) (point))
+	(goto-char (point-min)))
+    (or (word-at-point) "")))
+
+(defun speed-type--get-separated-thing-at-random-line (content-buffer limit separator)
+  "Get thing that is SEPARATOR at random line in CONTENT-BUFFER."
+  (with-current-buffer content-buffer
+    (save-excursion
+      (goto-char (point-min))
+      (beginning-of-line (+ 1 (random limit)))
+      (let ((seperated-things (split-string (or (thing-at-point 'line) "") separator)))
+	(dotimes (_  (random (length seperated-things)))
+	  (setq seperated-things (cdr seperated-things)))
+	(car seperated-things)))))
+
+(defun speed-type--get-random-word (content-buffer limit)
+  "Get random word in CONTENT-BUFFER.
+LIMIT is supplied to the random-function."
+  (with-current-buffer content-buffer
+    (save-excursion
+      (goto-char (point-min))
+      (beginning-of-line (+ 1 (random limit)))
+      (or (word-at-point) ""))))
+
+(defun speed-type-add-extra-words ()
+  "Add extra words of text to be typed for the typing-session to be complete."
+  (when (and (> (or speed-type-add-extra-words-on-mistake 0) 0)
+	     speed-type--add-extra-word-content-fn)
+    (let ((words '()))
+      (dotimes (_ speed-type-add-extra-words-on-mistake)
+	(let ((word (string-trim (funcall speed-type--add-extra-word-content-fn))))
+	  (if (string-empty-p word)
+	      (message "You got lucky! Extra word function resulted in empty string.")
+	    (push word words))))
+      (let ((words-as-string (concat " " (string-trim (mapconcat 'identity (nreverse words) " ")))))
+	(setq speed-type--extra-words-queue (append speed-type--extra-words-queue (split-string words-as-string "" t))
+	      speed-type--orig-text (concat speed-type--orig-text words-as-string)
+	      speed-type--mod-str (concat speed-type--mod-str (make-string (+ 1 (length words-as-string)) 0))
+	      speed-type--remaining (+ (length words-as-string) speed-type--remaining))))
+    (when (not (timerp speed-type--extra-words-animation-time))
+      (setq speed-type--extra-words-animation-time (run-at-time nil 0.01 'speed-type-animate-extra-word-inseration speed-type--buffer)))))
+
+(defun speed-type-finish-animation (buf)
+  "Insert all remaining characters in ‘speed-type--extra-words-queue’ to BUF."
+  (save-excursion
+    (with-current-buffer buf
+      (remove-hook 'after-change-functions 'speed-type--change t)
+      (when speed-type--extra-words-animation-time (cancel-timer speed-type--extra-words-animation-time))
+      (setq speed-type--extra-words-animation-time nil)
+      (when speed-type--extra-words-queue
+	(insert (mapconcat 'identity speed-type--extra-words-queue))
+	(unless (with-current-buffer speed-type--content-buffer (derived-mode-p 'prog-mode)
+				     (fill-region (point-min) (point-max) 'none t)))))))
+
+(defun speed-type-animate-extra-word-inseration (buf)
+  "Add words of punishment-lines in animated fashion to ‘BUF’."
+  (save-excursion
+    (with-current-buffer buf
+      (remove-hook 'after-change-functions 'speed-type--change t)
+      (if (and speed-type--extra-words-queue)
+	  (let ((token (pop speed-type--extra-words-queue)))
+	    (goto-char (point-max))
+	    (insert token))
+	(unless (with-current-buffer speed-type--content-buffer (derived-mode-p 'prog-mode))
+	  (fill-region (point-min) (point-max) 'none t))
+	(cancel-timer speed-type--extra-words-animation-time)
+	(setq speed-type--extra-words-animation-time nil))
+      (add-hook 'after-change-functions 'speed-type--change nil t))))
+
+(defun speed-type--code-tab ()
   "A command to be mapped to TAB when speed typing code."
   (interactive)
   (let ((start (point))
@@ -564,11 +750,11 @@ been completed."
     (goto-char start)
     (when end (insert (buffer-substring-no-properties start (1- end))))))
 
-(defun speed-type-code-ret ()
+(defun speed-type--code-ret ()
   "A command to be mapped to RET when speed typing code."
   (interactive)
   (when (= (point) (line-end-position))
-    (newline) (move-beginning-of-line nil) (speed-type-code-tab)))
+    (newline) (move-beginning-of-line nil) (speed-type--code-tab)))
 
 ;;;###autoload
 (defun speed-type-top-x (n)
@@ -583,21 +769,27 @@ been completed."
                   (insert-file-contents file-path)
                   (split-string (buffer-string) "\n" t)))
          (n (min n (length words)))
+	 (buf (speed-type-prepare-content-buffer file-path))
          (title (format "Top %s %s words" n lang))
+	 (text (with-temp-buffer
+		 (while (< (buffer-size) char-length)
+		   (insert (speed-type--get-random-word buf n))
+                   (insert " "))
+		 (fill-region (point-min) (point-max) 'none t)
+		 (if speed-type-wordlist-transform
+                     (funcall speed-type-wordlist-transform (buffer-string))
+                   (buffer-string))))
+	 (add-extra-word-content-fn (lambda () (speed-type--get-random-word buf n)))
          (go-next-fn (lambda () (speed-type-top-x n))))
-    (speed-type--setup (with-temp-buffer
-                         (while (< (buffer-size) char-length)
-                           (insert (nth (random n) words))
-                           (insert " "))
-                         (fill-region (point-min) (point-max))
-                         (if speed-type-wordlist-transform
-                             (funcall speed-type-wordlist-transform (buffer-string))
-                           (buffer-string)))
-                       :title title
-                       :lang lang
-                       :n-words n
-                       :replay-fn (speed-type--get-replay-fn go-next-fn)
-                       :go-next-fn go-next-fn)))
+    (speed-type--setup buf
+	     text
+             :title title
+	     :author "Uni Leipzig"
+             :lang lang
+             :n-words n
+	     :add-extra-word-content-fn add-extra-word-content-fn
+             :replay-fn #'speed-type--get-replay-fn
+             :go-next-fn go-next-fn)))
 
 ;;;###autoload
 (defun speed-type-top-100 ()
@@ -615,11 +807,24 @@ been completed."
 (defun speed-type-region (start end)
   "Open copy of [START,END] in a new buffer to speed type the text."
   (interactive "r")
-  (if (derived-mode-p 'prog-mode)
-      (speed-type--code-with-highlighting (buffer-substring-no-properties start end)
-                                          (syntax-table)
-                                          font-lock-defaults)
-    (speed-type--setup (buffer-substring-no-properties start end))))
+  (let* ((buf (speed-type-prepare-content-buffer-from-buffer (current-buffer)))
+	 (title (concat (buffer-name)
+			(when (and start end) " Region: ")
+			(when start (int-to-string start))
+			(when end (concat ":" (int-to-string end)))))
+         (text (with-current-buffer buf (buffer-substring-no-properties start end))))
+    (if (with-current-buffer buf (derived-mode-p 'prog-mode))
+        (speed-type--code-with-highlighting buf
+				  text
+				  title
+				  (user-full-name)
+				  (syntax-table)
+				  font-lock-defaults)
+      (speed-type--setup buf
+	       (buffer-substring-no-properties start end)
+	       :author (user-full-name)
+	       :title title
+	       :replay-fn #'speed-type--get-replay-fn))))
 
 ;;;###autoload
 (defun speed-type-buffer (full)
@@ -630,17 +835,28 @@ will be used.  Else some text will be picked randomly."
   (interactive "P")
   (if full
       (speed-type-region (point-min) (point-max))
-    (let* ((buf (current-buffer))
-           (text (speed-type--pick-text-to-type))
+    (let* ((buf (speed-type-prepare-content-buffer-from-buffer (current-buffer)))
+           (text (with-current-buffer buf
+		   (speed-type--pick-text-to-type)))
+	   (line-count (with-current-buffer buf (count-lines (point-min) (point-max))))
            (go-next-fn (lambda ()
                          (with-current-buffer buf
                            (speed-type-buffer nil)))))
-      (if (derived-mode-p 'prog-mode)
-          (speed-type--code-with-highlighting text
-                                              (syntax-table)
-                                              font-lock-defaults
-                                              go-next-fn)
-        (speed-type--setup text :go-next-fn go-next-fn)))))
+      (if (with-current-buffer buf
+	    (derived-mode-p 'prog-mode))
+          (speed-type--code-with-highlighting buf
+				    text
+				    (user-full-name)
+				    (buffer-name)
+                                    (syntax-table)
+                                    font-lock-defaults
+                                    go-next-fn)
+        (speed-type--setup buf
+		 text
+		 :author (user-full-name)
+		 :title (buffer-name)
+		 :add-extra-word-content-fn (lambda () (speed-type--get-separated-thing-at-random-line buf line-count " "))
+		 :go-next-fn go-next-fn)))))
 
 ;;;###autoload
 (defun speed-type-text ()
@@ -648,39 +864,35 @@ will be used.  Else some text will be picked randomly."
   (interactive)
   (let* ((book-num (nth (random (length speed-type-gb-book-list))
                         speed-type-gb-book-list))
-         (author nil)
-         (title nil)
-         (fn (speed-type--gb-retrieve book-num)))
-
-    (if fn
-        (with-temp-buffer
-          (insert-file-contents fn)
-          (goto-char 0)
-          (when (re-search-forward "^Title: " nil t)
-            (setq title (buffer-substring (point) (line-end-position))))
-          (when (re-search-forward "^Author: " nil t)
-            (setq author (buffer-substring (point) (line-end-position))))
-
-          (let ((start (point))
-                (end nil))
-
-            (goto-char (point-min))
-            (when (re-search-forward "***.START.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
-              (end-of-line 1)
-              (forward-line 1)
-              (setq start (point)))
-            (when (re-search-forward "***.END.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
-              (beginning-of-line 1)
-              (forward-line -1)
-              (setq end (point)))
-
-            (speed-type--setup (speed-type--pick-text-to-type start end)
-                               :author author
-                               :title title
-                               :replay-fn (speed-type--get-replay-fn #'speed-type-text)
-                               :go-next-fn #'speed-type-text)))
-      (message "Error retrieving book number %s" book-num))))
+         (fn (speed-type--gb-retrieve book-num))
+	 (buf (speed-type-prepare-content-buffer fn))
+	 (title (with-current-buffer buf
+		  (save-excursion
+		    (when (re-search-forward "^Title: " nil t)
+		      (buffer-substring (point) (line-end-position))))))
+	 (author (with-current-buffer buf
+		   (save-excursion
+		     (when (re-search-forward "^Author: " nil t)
+		       (buffer-substring (point) (line-end-position))))))
+	 (start (with-current-buffer buf
+		  (when (re-search-forward "***.START.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
+		    (end-of-line 1)
+		    (forward-line 1)
+		    (point))))
+	 (end (with-current-buffer buf
+		(when (re-search-forward "***.END.OF.\\(THIS\\|THE\\).PROJECT.GUTENBERG.EBOOK" nil t)
+		  (beginning-of-line 1)
+		  (forward-line -1)
+		  (point))))
+	 (text (with-current-buffer buf
+		 (speed-type--pick-text-to-type start end))))
+    (speed-type--setup buf
+	     text
+             :author author
+             :title title
+	     :add-extra-word-content-fn (lambda () (speed-type--get-next-word buf))
+             :replay-fn #'speed-type--get-replay-fn
+             :go-next-fn #'speed-type-text)))
 
 (provide 'speed-type)
-
 ;;; speed-type.el ends here


### PR DESCRIPTION
Hi

I went through the Issues and open Pull requests.

I fixed following Issues:
- https://github.com/dakra/speed-type/issues/37 (my own)
- https://github.com/dakra/speed-type/issues/11 and https://github.com/dakra/speed-type/pull/42/files (obsolete)
- https://github.com/dakra/speed-type/issues/9 (maybe, not sure how to reproduce)

Not done:
- Getting the next-content from content-buffer in speed-type-text (instead of making a request to gutenberg again)

- [ ] Make my repo up to date with the 2 missing commits in your repo
- [ ] Will remove the README.md changes.
- [ ] There is a bug with fill-region and org-mode tags

This is not a draft. I won't add more functionality in this pull request. I fix bugs, refactor code or cleanup duplicate code.

I know you have no time for so much code to review. Let me know, how I should continue.