### PR TITLE
Adjust face definition and pick only existing speed-type-overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ character where previous character was already an error.
 
 You can make consecutive errors yellow/orange (warning-color) by customizing the face as follows:
 ```emacs-lisp
-(face-spec-set 'speed-type-consecutive-error-face `((t (:inherit 'default :foreground ,(face-foreground 'warning) :underline t))))
+(face-spec-set 'speed-type-consecutive-error-face '((t :inherit warning :underline t)))
 ```
 
 ### Statistics


### PR DESCRIPTION
https://github.com/dakra/speed-type/issues/69 Fix warnings in relation with themes due to undefined faces while initalizing

https://github.com/dakra/speed-type/issues/70 and https://github.com/dakra/speed-type/issues/64 Fix overlay which made the whole line green/red when using hl-line-mode. hl-line adds a overlay which spans the whole line. We now add a separate overlay for the speed-type-face.