### PR TITLE
68 Introduce speed-type-text-top-x to support more languages. + 14

### DIFF
--- a/test-speed-type.el
+++ b/test-speed-type.el
@@ -69,18 +69,18 @@
     (speed-type--retrieve-non-existant-file-environment
      filename-expected
      (lambda ()
-       (let ((filename-response (speed-type--retrieve filename url)))
-         (should (stringp filename-response))
-         (should (string= filename-response filename-expected))
+       (let ((response (speed-type--retrieve filename url)))
+         (should (bufferp response))
+         (should (string= (buffer-file-name response) filename-expected))
          (should (file-exists-p filename-expected))
          (should (file-readable-p filename-expected)))))
 
     (speed-type--retrieve-existant-file-environment
      filename-expected
      (lambda ()
-       (let ((filename-response (speed-type--retrieve filename url)))
-         (should (stringp filename-response))
-         (should (string= filename-response filename-expected))
+       (let ((response (speed-type--retrieve filename url)))
+         (should (bufferp response))
+         (should (string= (buffer-file-name response) filename-expected))
          (should (file-exists-p filename-expected))
          (should (file-readable-p filename-expected))))))
 
@@ -91,7 +91,7 @@
     (speed-type--retrieve-non-existant-file-environment
      filename-expected
      (lambda ()
-       (let ((filename-response (speed-type--retrieve filename url)))
-         (should (null filename-response))
+       (let ((response (speed-type--retrieve filename url)))
+         (should (null response))
          (should (not (file-exists-p filename-expected)))
          (should (not (file-readable-p filename-expected))))))))


### PR DESCRIPTION
Fixes #68
Fixes #14

Correct typo speed-type-pause-dealy-seconds ->
speed-type-pause-delay-seconds and actually use it

Correct case when word is blank when adding words due to error

Correct whitespace check for unicode-characters

Replace TAB with ⇥ (RIGHTWARDS ARROW TO BAR) in preview

Increase window-size for preview-buffer for also have enough space when header-lines are active

Refactoring:
- Work with buffer instead of file-name, deduce file-name from buffer, adjust tests
- prepare-buffer always from buffer